### PR TITLE
Feat/add events api tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@
 
 # Rest API em Node.js e Express.js - Planner para registro e consulta de usuários e eventos
 
-Essa aplicação em JavaScript segue a proposta de "Um planner que irá ajudar o cliente a organizar sua semanas, tarefas e quando elas acontecem". Referente ao "challenge 1" do programa de bolsas Back-end Journey (Node.js) da Compass Uol. Nela foram implementadas as funções de:   
+> Projeto desenvolvido para estudos de API RESTful com Express e Node.js
+
+Essa aplicação em JavaScript segue a proposta de "Um planner que irá ajudar o cliente a organizar sua semanas, tarefas e quando elas acontecem". Nela foram implementadas as funções de:   
 
 **Usuários** - listar todos os usuários, sign up e sign in;    
 **Eventos** - criar novo evento, listar todos os eventos, listar eventos pelo id ou dia da semana e deletar eventos pelo id ou dia da semana.
 
-No momento não é usado banco de dados. Os usuários e eventos são registrados em arquivos JSON, users.json e events.json, respectivamente.
+No momento não é usado banco de dados. Os usuários e eventos são registrados em arquivos JSON, users.json e events.json, respectivamente.   
 
 ## Índice
 <!--ts-->
@@ -392,7 +394,32 @@ Caso tente acessar algum rota que não foi definida, é retornada a mensagem:
    ![image](https://user-images.githubusercontent.com/103967442/218486562-e157803c-82bc-48dc-9a84-869a1303bda8.png)
 
    Lembrando que para realizar o deploy, em ./scr/server.js a porta deve ser process.env.PORT e em package.json o "script" deve ser ```"start": "node ./src/server.js"```  
-     
+
+## 🧪 Testes Automatizados das Rotas de Eventos
+
+Este projeto inclui um script para **testes automatizados das rotas de eventos** da API, garantindo que funcionalidades essenciais continuem funcionando corretamente após alterações no código.
+
+### Como executar os testes
+
+1. Certifique-se de que a API está rodando localmente (`npm start` ou `node src/server.js`).
+2. No terminal, execute: ```node testEvents.js```
+
+
+### O que é testado
+
+O script `testEvents.js` realiza os seguintes testes automáticos:
+- Criação de evento com dados válidos (`POST /api/v1/events`)
+- Tentativa de criação de evento com data inválida (esperando erro)
+- Consulta de eventos (`GET /api/v1/events`)
+- Consulta de evento específico por ID (`GET /api/v1/events/:id`)
+- Exclusão de evento por ID (`DELETE /api/v1/events/:id`)
+
+Ao final, o resultado de cada teste é exibido diretamente no terminal, indicando sucesso ou detalhes do erro retornado pela API.
+
+### Objetivo
+
+Esses testes garantem que, a cada alteração ou correção realizada, as principais rotas de eventos continuam funcionando conforme o esperado, reduzindo o risco de bugs passarem despercebidos para produção.
+
 
 ## Créditos  
 Para o desenvolvimento dessa API, foram usados os conhecimentos adquiridos no curso Node.js, Express, MongoDB & More: The Complete Bootcamp 2023 

--- a/testEvents.js
+++ b/testEvents.js
@@ -1,0 +1,80 @@
+const axios = require('axios');
+
+const API_URL = 'http://localhost:3000/api/v1/events'; // ajuste a porta se necessário
+
+// Helper para exibir resultados no terminal
+function log(title, result) {
+  console.log(`\n--- ${title} ---`);
+  if (result instanceof Error) {
+    console.error(result.response ? result.response.data : result.message);
+  } else {
+    console.log(result.data || result);
+  }
+}
+
+// Teste de criação de evento válido
+async function testCreateValidEvent() {
+  try {
+    const res = await axios.post(API_URL, {
+      description: 'Reunião de planejamento',
+      dateTime: '2025/07/03'
+    });
+    log('Create Event (Valid)', res);
+    return res.data.data.eventData.id;
+  } catch (err) {
+    log('Create Event (Valid) - ERROR', err);
+  }
+}
+
+// Teste de criação de evento com data inválida
+async function testCreateInvalidEvent() {
+  try {
+    await axios.post(API_URL, {
+      description: 'Evento com data inválida',
+      dateTime: '2025-07-03' // formato inválido
+    });
+  } catch (err) {
+    log('Create Event (Invalid Date) - EXPECTED ERROR', err);
+  }
+}
+
+// Teste de consulta de todos os eventos
+async function testGetAllEvents() {
+  try {
+    const res = await axios.get(API_URL);
+    log('Get All Events', res);
+  } catch (err) {
+    log('Get All Events - ERROR', err);
+  }
+}
+
+// Teste de consulta de evento por ID
+async function testGetEventById(id) {
+  try {
+    const res = await axios.get(`${API_URL}/${id}`);
+    log('Get Event By ID', res);
+  } catch (err) {
+    log('Get Event By ID - ERROR', err);
+  }
+}
+
+// Teste de deleção de evento por ID
+async function testDeleteEventById(id) {
+  try {
+    const res = await axios.delete(`${API_URL}/${id}`);
+    log('Delete Event By ID', res);
+  } catch (err) {
+    log('Delete Event By ID - ERROR', err);
+  }
+}
+
+// Fluxo de execução dos testes
+(async () => {
+  await testCreateInvalidEvent();
+  const eventId = await testCreateValidEvent();
+  if (eventId) {
+    await testGetEventById(eventId);
+    await testDeleteEventById(eventId);
+  }
+  await testGetAllEvents();
+})();


### PR DESCRIPTION
Adiciona o script testEvents.js para testes automatizados das rotas de eventos (criação, consulta, deleção e data inválida).
O README.md foi atualizado com instruções de uso dos testes.
Para testar, basta rodar  `node testEvents.js` com a API em execução.